### PR TITLE
fix api version in urls in config/urls and resource names

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -8,8 +8,10 @@ from rest_framework import permissions
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    path('user/', include("dideban.user.api.v1.rest.urls"), name="user"),
-    path('team/', include("dideban.team.api.v1.rest.urls"), name="team"),
+    path('api/v1/', include([
+        path('users/', include("dideban.user.api.v1.rest.urls"), name="user"),
+        path('teams/', include("dideban.team.api.v1.rest.urls"), name="team"),
+    ])),
 ]
 
 if settings.DEBUG:


### PR DESCRIPTION
in order to have clean resource names should use plurals in URLs 
[reference](https://restfulapi.net/resource-naming/)